### PR TITLE
docs: Charter Checkバッジの注意書きを追加、check-local-charter-versionのバグ修正を適用

### DIFF
--- a/README-jp.md
+++ b/README-jp.md
@@ -50,6 +50,9 @@
    - dev-charter の cron スケジュールをランダム化
 4. ワークフローをカスタマイズする（`DEVELOPING.md` 参照）
 
+> **Note:** README を書き換える際、Charter Check バッジ（`dev-charter-check.yml` の badge）が
+> 消えやすい。`README.md` / `README-jp.md` の両方に残っているか確認する。
+
 ### Development (this template)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@
    - Randomize the dev-charter cron schedule
 4. Customize the workflow (see `DEVELOPING.md`)
 
+> **Note:** When rewriting the README, the Charter Check badge (for `dev-charter-check.yml`)
+> is easy to lose. Verify it's still present in both `README.md` and `README-jp.md`.
+
 ### Development (this template)
 
 ```bash

--- a/docs/dev-charter/scripts/check-local-charter-version.ps1
+++ b/docs/dev-charter/scripts/check-local-charter-version.ps1
@@ -1,43 +1,46 @@
 #!/usr/bin/env pwsh
 # PowerShell counterpart of check-local-charter-version.sh (same behavior).
 # Compare this repo's installed dev-charter VERSION against a sibling
-# ../dev-charter checkout.
+# ../dev-charter checkout's main branch.
 #
 # Expected layout:
 #   <parent>/dev-charter/     a local clone of dev-charter
 #   <parent>/<this-repo>/     this repository
 #
-# - sibling newer than installed  -> block (a confirmed, actionable gap: run git subtree pull)
-# - sibling older than installed  -> warn only (sibling itself may just be un-pulled)
-# - equal, or either VERSION file missing -> silent
+# - sibling main newer than installed  -> block (a confirmed, actionable gap: run git subtree pull)
+# - sibling main older than installed  -> warn only (sibling itself may just be un-pulled)
+# - equal, or either VERSION unavailable -> silent
 #
-# Override with CHARTER_PREFIX / CHARTER_LOCAL_PATH env vars if needed.
+# Reads VERSION from the sibling's local `main` ref (not its working tree), so
+# the result doesn't depend on whatever branch happens to be checked out there.
+# Override with CHARTER_PREFIX / CHARTER_LOCAL_PATH / CHARTER_LOCAL_REF env vars if needed.
 $ErrorActionPreference = 'Stop'
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
 $repoRoot = (git rev-parse --show-toplevel).Trim()
 $prefix = if ($env:CHARTER_PREFIX) { $env:CHARTER_PREFIX } else { 'docs/dev-charter' }
 $localCharter = if ($env:CHARTER_LOCAL_PATH) { $env:CHARTER_LOCAL_PATH } else { Join-Path (Split-Path $repoRoot -Parent) 'dev-charter' }
+$localRef = if ($env:CHARTER_LOCAL_REF) { $env:CHARTER_LOCAL_REF } else { 'main' }
 
 $installedVersionFile = Join-Path $repoRoot "$prefix/VERSION"
-$localVersionFile = Join-Path $localCharter 'VERSION'
 
 if (-not (Test-Path $installedVersionFile)) { exit 0 }
-if (-not (Test-Path $localVersionFile)) { exit 0 }
+if (-not (Test-Path $localCharter)) { exit 0 }
 
 $installed = Get-Content -Path $installedVersionFile -TotalCount 1
-$local = Get-Content -Path $localVersionFile -TotalCount 1
+$local = (git -C $localCharter show "${localRef}:VERSION" 2>$null | Select-Object -First 1)
+if ([string]::IsNullOrEmpty($local)) { exit 0 }
 
 if ($local -eq $installed) {
     exit 0
 }
 
 if ([string]::CompareOrdinal($local, $installed) -gt 0) {
-    Write-Host "error: ${localCharter} の VERSION (${local}) が ${prefix}/VERSION (${installed}) より新しいです。"
+    Write-Host "error: ${localCharter} の ${localRef} ブランチの VERSION (${local}) が ${prefix}/VERSION (${installed}) より新しいです。"
     Write-Host '  git subtree pull で dev-charter を更新してからコミットしてください。'
     exit 1
 }
 
-Write-Host "warning: ${localCharter} の VERSION (${local}) は ${prefix}/VERSION (${installed}) より古いです。"
-Write-Host "  (${localCharter} 自体が fetch/pull 済みでない可能性があるため、警告にとどめています)"
+Write-Host "warning: ${localCharter} の ${localRef} ブランチの VERSION (${local}) は ${prefix}/VERSION (${installed}) より古いです。"
+Write-Host "  (${localCharter} の ${localRef} 自体が fetch/pull 済みでない可能性があるため、警告にとどめています)"
 exit 0

--- a/docs/dev-charter/scripts/check-local-charter-version.sh
+++ b/docs/dev-charter/scripts/check-local-charter-version.sh
@@ -1,41 +1,44 @@
 #!/usr/bin/env bash
 # Compare this repo's installed dev-charter VERSION against a sibling
-# ../dev-charter checkout.
+# ../dev-charter checkout's main branch.
 #
 # Expected layout:
 #   <parent>/dev-charter/     a local clone of dev-charter
 #   <parent>/<this-repo>/     this repository
 #
-# - sibling newer than installed  -> block (a confirmed, actionable gap: run git subtree pull)
-# - sibling older than installed  -> warn only (sibling itself may just be un-pulled)
-# - equal, or either VERSION file missing -> silent
+# - sibling main newer than installed  -> block (a confirmed, actionable gap: run git subtree pull)
+# - sibling main older than installed  -> warn only (sibling itself may just be un-pulled)
+# - equal, or either VERSION unavailable -> silent
 #
-# Override with CHARTER_PREFIX / CHARTER_LOCAL_PATH env vars if needed.
+# Reads VERSION from the sibling's local `main` ref (not its working tree), so
+# the result doesn't depend on whatever branch happens to be checked out there.
+# Override with CHARTER_PREFIX / CHARTER_LOCAL_PATH / CHARTER_LOCAL_REF env vars if needed.
 set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 PREFIX="${CHARTER_PREFIX:-docs/dev-charter}"
 LOCAL_CHARTER="${CHARTER_LOCAL_PATH:-$(dirname "$REPO_ROOT")/dev-charter}"
+LOCAL_REF="${CHARTER_LOCAL_REF:-main}"
 
 INSTALLED_VERSION_FILE="${REPO_ROOT}/${PREFIX}/VERSION"
-LOCAL_VERSION_FILE="${LOCAL_CHARTER}/VERSION"
 
 [ -f "$INSTALLED_VERSION_FILE" ] || exit 0
-[ -f "$LOCAL_VERSION_FILE" ] || exit 0
+[ -d "$LOCAL_CHARTER" ] || exit 0
 
 INSTALLED=$(head -1 "$INSTALLED_VERSION_FILE")
-LOCAL=$(head -1 "$LOCAL_VERSION_FILE")
+LOCAL=$(git -C "$LOCAL_CHARTER" show "${LOCAL_REF}:VERSION" 2>/dev/null | head -1) || exit 0
+[ -n "$LOCAL" ] || exit 0
 
 if [ "$LOCAL" = "$INSTALLED" ]; then
   exit 0
 fi
 
 if [[ "$LOCAL" > "$INSTALLED" ]]; then
-  echo "error: ${LOCAL_CHARTER} の VERSION (${LOCAL}) が ${PREFIX}/VERSION (${INSTALLED}) より新しいです。"
+  echo "error: ${LOCAL_CHARTER} の ${LOCAL_REF} ブランチの VERSION (${LOCAL}) が ${PREFIX}/VERSION (${INSTALLED}) より新しいです。"
   echo "  git subtree pull で dev-charter を更新してからコミットしてください。"
   exit 1
 fi
 
-echo "warning: ${LOCAL_CHARTER} の VERSION (${LOCAL}) は ${PREFIX}/VERSION (${INSTALLED}) より古いです。"
-echo "  (${LOCAL_CHARTER} 自体が fetch/pull 済みでない可能性があるため、警告にとどめています)"
+echo "warning: ${LOCAL_CHARTER} の ${LOCAL_REF} ブランチの VERSION (${LOCAL}) は ${PREFIX}/VERSION (${INSTALLED}) より古いです。"
+echo "  (${LOCAL_CHARTER} の ${LOCAL_REF} 自体が fetch/pull 済みでない可能性があるため、警告にとどめています)"
 exit 0

--- a/scripts/check-local-charter-version.ps1
+++ b/scripts/check-local-charter-version.ps1
@@ -1,43 +1,46 @@
 #!/usr/bin/env pwsh
 # PowerShell counterpart of check-local-charter-version.sh (same behavior).
 # Compare this repo's installed dev-charter VERSION against a sibling
-# ../dev-charter checkout.
+# ../dev-charter checkout's main branch.
 #
 # Expected layout:
 #   <parent>/dev-charter/     a local clone of dev-charter
 #   <parent>/<this-repo>/     this repository
 #
-# - sibling newer than installed  -> block (a confirmed, actionable gap: run git subtree pull)
-# - sibling older than installed  -> warn only (sibling itself may just be un-pulled)
-# - equal, or either VERSION file missing -> silent
+# - sibling main newer than installed  -> block (a confirmed, actionable gap: run git subtree pull)
+# - sibling main older than installed  -> warn only (sibling itself may just be un-pulled)
+# - equal, or either VERSION unavailable -> silent
 #
-# Override with CHARTER_PREFIX / CHARTER_LOCAL_PATH env vars if needed.
+# Reads VERSION from the sibling's local `main` ref (not its working tree), so
+# the result doesn't depend on whatever branch happens to be checked out there.
+# Override with CHARTER_PREFIX / CHARTER_LOCAL_PATH / CHARTER_LOCAL_REF env vars if needed.
 $ErrorActionPreference = 'Stop'
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
 $repoRoot = (git rev-parse --show-toplevel).Trim()
 $prefix = if ($env:CHARTER_PREFIX) { $env:CHARTER_PREFIX } else { 'docs/dev-charter' }
 $localCharter = if ($env:CHARTER_LOCAL_PATH) { $env:CHARTER_LOCAL_PATH } else { Join-Path (Split-Path $repoRoot -Parent) 'dev-charter' }
+$localRef = if ($env:CHARTER_LOCAL_REF) { $env:CHARTER_LOCAL_REF } else { 'main' }
 
 $installedVersionFile = Join-Path $repoRoot "$prefix/VERSION"
-$localVersionFile = Join-Path $localCharter 'VERSION'
 
 if (-not (Test-Path $installedVersionFile)) { exit 0 }
-if (-not (Test-Path $localVersionFile)) { exit 0 }
+if (-not (Test-Path $localCharter)) { exit 0 }
 
 $installed = Get-Content -Path $installedVersionFile -TotalCount 1
-$local = Get-Content -Path $localVersionFile -TotalCount 1
+$local = (git -C $localCharter show "${localRef}:VERSION" 2>$null | Select-Object -First 1)
+if ([string]::IsNullOrEmpty($local)) { exit 0 }
 
 if ($local -eq $installed) {
     exit 0
 }
 
 if ([string]::CompareOrdinal($local, $installed) -gt 0) {
-    Write-Host "error: ${localCharter} の VERSION (${local}) が ${prefix}/VERSION (${installed}) より新しいです。"
+    Write-Host "error: ${localCharter} の ${localRef} ブランチの VERSION (${local}) が ${prefix}/VERSION (${installed}) より新しいです。"
     Write-Host '  git subtree pull で dev-charter を更新してからコミットしてください。'
     exit 1
 }
 
-Write-Host "warning: ${localCharter} の VERSION (${local}) は ${prefix}/VERSION (${installed}) より古いです。"
-Write-Host "  (${localCharter} 自体が fetch/pull 済みでない可能性があるため、警告にとどめています)"
+Write-Host "warning: ${localCharter} の ${localRef} ブランチの VERSION (${local}) は ${prefix}/VERSION (${installed}) より古いです。"
+Write-Host "  (${localCharter} の ${localRef} 自体が fetch/pull 済みでない可能性があるため、警告にとどめています)"
 exit 0

--- a/scripts/check-local-charter-version.sh
+++ b/scripts/check-local-charter-version.sh
@@ -1,41 +1,44 @@
 #!/usr/bin/env bash
 # Compare this repo's installed dev-charter VERSION against a sibling
-# ../dev-charter checkout.
+# ../dev-charter checkout's main branch.
 #
 # Expected layout:
 #   <parent>/dev-charter/     a local clone of dev-charter
 #   <parent>/<this-repo>/     this repository
 #
-# - sibling newer than installed  -> block (a confirmed, actionable gap: run git subtree pull)
-# - sibling older than installed  -> warn only (sibling itself may just be un-pulled)
-# - equal, or either VERSION file missing -> silent
+# - sibling main newer than installed  -> block (a confirmed, actionable gap: run git subtree pull)
+# - sibling main older than installed  -> warn only (sibling itself may just be un-pulled)
+# - equal, or either VERSION unavailable -> silent
 #
-# Override with CHARTER_PREFIX / CHARTER_LOCAL_PATH env vars if needed.
+# Reads VERSION from the sibling's local `main` ref (not its working tree), so
+# the result doesn't depend on whatever branch happens to be checked out there.
+# Override with CHARTER_PREFIX / CHARTER_LOCAL_PATH / CHARTER_LOCAL_REF env vars if needed.
 set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 PREFIX="${CHARTER_PREFIX:-docs/dev-charter}"
 LOCAL_CHARTER="${CHARTER_LOCAL_PATH:-$(dirname "$REPO_ROOT")/dev-charter}"
+LOCAL_REF="${CHARTER_LOCAL_REF:-main}"
 
 INSTALLED_VERSION_FILE="${REPO_ROOT}/${PREFIX}/VERSION"
-LOCAL_VERSION_FILE="${LOCAL_CHARTER}/VERSION"
 
 [ -f "$INSTALLED_VERSION_FILE" ] || exit 0
-[ -f "$LOCAL_VERSION_FILE" ] || exit 0
+[ -d "$LOCAL_CHARTER" ] || exit 0
 
 INSTALLED=$(head -1 "$INSTALLED_VERSION_FILE")
-LOCAL=$(head -1 "$LOCAL_VERSION_FILE")
+LOCAL=$(git -C "$LOCAL_CHARTER" show "${LOCAL_REF}:VERSION" 2>/dev/null | head -1) || exit 0
+[ -n "$LOCAL" ] || exit 0
 
 if [ "$LOCAL" = "$INSTALLED" ]; then
   exit 0
 fi
 
 if [[ "$LOCAL" > "$INSTALLED" ]]; then
-  echo "error: ${LOCAL_CHARTER} の VERSION (${LOCAL}) が ${PREFIX}/VERSION (${INSTALLED}) より新しいです。"
+  echo "error: ${LOCAL_CHARTER} の ${LOCAL_REF} ブランチの VERSION (${LOCAL}) が ${PREFIX}/VERSION (${INSTALLED}) より新しいです。"
   echo "  git subtree pull で dev-charter を更新してからコミットしてください。"
   exit 1
 fi
 
-echo "warning: ${LOCAL_CHARTER} の VERSION (${LOCAL}) は ${PREFIX}/VERSION (${INSTALLED}) より古いです。"
-echo "  (${LOCAL_CHARTER} 自体が fetch/pull 済みでない可能性があるため、警告にとどめています)"
+echo "warning: ${LOCAL_CHARTER} の ${LOCAL_REF} ブランチの VERSION (${LOCAL}) は ${PREFIX}/VERSION (${INSTALLED}) より古いです。"
+echo "  (${LOCAL_CHARTER} の ${LOCAL_REF} 自体が fetch/pull 済みでない可能性があるため、警告にとどめています)"
 exit 0


### PR DESCRIPTION
## Summary
- README書き換え時にCharter Checkバッジが消えやすい問題への注意書きを追加
- check-local-charter-versionがsiblingの作業ツリー（未マージのWIPブランチ等）をそのまま読んでいた不具合の修正版（y-marui/dev-charter#63）を適用

## Test plan
- [x] `bash scripts/check-local-charter-version.sh` が exit 0 で通ることを確認